### PR TITLE
Fail gracefully when null message is passed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	"require-dev": {
 		"nette/bootstrap": "^3.0",
 		"nette/database": "^3.0",
+		"nette/forms": "^3.0",
 		"nette/robot-loader": " ^3.0",
 		"nette/tester": "^2.2",
 		"doctrine/orm": "^2.6",

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -327,6 +327,10 @@ class Translator extends Symfony\Component\Translation\Translator implements Net
 		$domain = array_key_exists(2, $parameters) ? $parameters[2] : null;
 		$locale = array_key_exists(3, $parameters) ? $parameters[3] : null;
 
+		if ($message === null) {
+			return '';
+		}
+
 		if (is_array($count)) {
 			$locale = $domain !== null ? (string) $domain : null;
 			$domain = $params !== null && !empty($params) ? (string) $params : null;

--- a/tests/tests/Translator.phpt
+++ b/tests/tests/Translator.phpt
@@ -10,6 +10,7 @@ namespace Contributte\Translation\Tests\Tests;
 
 use Contributte;
 use Nette;
+use Nette\Forms\Form;
 use Tester;
 
 $container = require __DIR__ . '/../bootstrap.php';
@@ -143,6 +144,40 @@ class Translator extends Contributte\Translation\Tests\AbstractTest
 
 		$prefixedTranslator = $translator->domain('messages');
 		Tester\Assert::same('Hello', $prefixedTranslator->translate('hello'));
+	}
+
+
+	public function testForm(): void
+	{
+		$configurator = new Nette\Configurator;
+
+		$configurator->setTempDirectory($this->container->getParameters()['tempDir'])
+			->addConfig([
+				'extensions' => [
+					'translation' => Contributte\Translation\DI\TranslationExtension::class,
+				],
+				'translation' => [
+					'debug' => true,
+					'locales' => [
+						'default' => 'en',
+					],
+					'dirs' => [
+						__DIR__ . '/../lang',
+					],
+				],
+			]);
+
+		$container = $configurator->createContainer();
+
+		/** @var Contributte\Translation\Translator $translator */
+		$translator = $container->getByType(Nette\Localization\ITranslator::class);
+
+		$form = new Form;
+		$form->setTranslator($translator);
+		$form->addText('name');
+		$form->addText('age', 'messages.depth.message');
+
+		Tester\Assert::contains('Depth message', (string) $form);
 	}
 }
 


### PR DESCRIPTION
`nette/forms` use `NULL` labels by default but we expect they are always string, let's relax the assumption.

Actually, the signature of the interface method is

    ITranslator::translate(mixed $message, ?int $count): string

but it is not really apparent how to implement it for other types than `?string`.