### PR TITLE
Allow autowiring translator by Symfony\Contracts\Translation\TranslatorInterface

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -121,11 +121,11 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 		}
 
 		$translator = $builder->addDefinition($this->prefix('translator'))
-			->setType(Nette\Localization\ITranslator::class)
 			->setFactory($factory, ['defaultLocale' => $this->config->locales->default, 'cacheDir' => $this->config->cache->dir, 'debug' => $this->config->debug])
 			->addSetup('setLocalesWhitelist', [$this->config->locales->whitelist])
 			->addSetup('setConfigCacheFactory', [$configCacheFactory])
-			->addSetup('setFallbackLocales', [$this->config->locales->fallback]);
+			->addSetup('setFallbackLocales', [$this->config->locales->fallback])
+			->setAutowired([Nette\Localization\ITranslator::class, Symfony\Contracts\Translation\TranslatorInterface::class]);
 
 		// Loaders
 		foreach ($this->config->loaders as $k1 => $v1) {

--- a/tests/Tests/DI/TranslationExtension.phpt
+++ b/tests/Tests/DI/TranslationExtension.phpt
@@ -97,6 +97,9 @@ class TranslationExtension extends Tests\TestAbstract
 		$foo = end($foo);
 		Tester\Assert::same('messages', end($foo));
 		Tester\Assert::true(Nette\Utils\Strings::contains(key($foo), 'messages.cs_CZ.neon'));
+
+		$symfonyTranslator = $container->getByType(Symfony\Contracts\Translation\TranslatorInterface::class);
+		Tester\Assert::same($translator, $symfonyTranslator);
 	}
 
 	public function test04(): void


### PR DESCRIPTION
Closes #15 