### PR TITLE
Allow using constants in configuration

### DIFF
--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -36,7 +36,9 @@ class TranslationExtension extends Nette\DI\CompilerExtension
 				}),
 				'default' => Expect::string('en'),
 				'fallback' => Expect::array()->default(null),
-			])->assert(function (stdClass $locales): bool {
+			])->before(function (array $array): array {
+				return Nette\DI\Helpers::filterArguments($array);
+			})->assert(function (stdClass $locales): bool {
 				if ($locales->whitelist !== null && !in_array($locales->default, $locales->whitelist, true)) {
 					throw new Contributte\Translation\Exceptions\InvalidArgument('If you set whitelist, default locale must be on him.');
 				}

--- a/tests/Tests/DI/TranslationExtension.phpt
+++ b/tests/Tests/DI/TranslationExtension.phpt
@@ -16,6 +16,9 @@ $container = require __DIR__ . '/../../bootstrap.php';
 class TranslationExtension extends Tests\TestAbstract
 {
 
+	public const LANGUAGE_1 = 'en';
+	public const LANGUAGE_2 = 'en';
+
 	public function test01(): void
 	{
 		Tester\Assert::exception(function (): void {
@@ -37,6 +40,16 @@ class TranslationExtension extends Tests\TestAbstract
 				],
 			]);
 		}, Contributte\Translation\Exceptions\InvalidArgument::class, 'If you set whitelist, default locale must be on him.');
+		Tester\Assert::noError(function (): void {
+			Tests\Helpers::createContainerFromConfigurator($this->container->getParameters()['tempDir'], [
+				'translation' => [
+					'locales' => [
+						'whitelist' => ['\Tests\DI\TranslationExtension::LANGUAGE_1'],
+						'default' => '\Tests\DI\TranslationExtension::LANGUAGE_2',
+					],
+				],
+			]);
+		});
 		Tester\Assert::exception(function (): void {
 			Tests\Helpers::createContainerFromConfigurator($this->container->getParameters()['tempDir'], [
 				'translation' => [


### PR DESCRIPTION
Hey.
Right now it is not possible to use something like this as ` \Translation:LOCALE_EN` is not in whitelist based on the `assert()` call.
```
translation:
    locales:
        default: \Translation:LOCALE_EN
        whitelist: ['en', 'cs']
```
It is failing because of these two validations (If you remove them, it will works fine):
- https://github.com/contributte/translation/blob/master/src/DI/TranslationExtension.php#L30
- https://github.com/contributte/translation/blob/master/src/DI/TranslationExtension.php#L39

This change will fix that issue, as it will call `before()` to replace constants with values.
I added one test, which can looks little bit odd, as It have two constants with same value.
But thx to it, I am able to test both validations in one test. ;)
