### PR TITLE
Spaces in message gives default domain

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -23,7 +23,7 @@ class Helpers
 	 */
 	public static function extractMessage(string $message): array
 	{
-		if (strpos($message, '.') !== false && strpos($message, ' ') === false) {
+		if (strpos($message, '.') !== false) {
 			[$domain, $message] = explode('.', $message, 2);
 
 		} else {


### PR DESCRIPTION
Correct issue when message to translate contains spaces. Then helper doesn't explode domain and message by '.' and set default domain 'messages' instead.