### PR TITLE
composer: autoload - compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
   "autoload": {
     "psr-4": {
       "Contributte\\Translation\\": "src"
-    }
+    },
+    "classmap": ["src/compatibility.php"]
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
I added the compatibility file to composer autoloader as `classmap`, so it does not scream.

<img width="1005" alt="Screenshot 2020-12-08 at 11 05 47" src="https://user-images.githubusercontent.com/1543737/101469752-6bdb6880-3945-11eb-88bd-7be18094cbd0.png">
