### PR TITLE
LocaleResolved::addResolver(): Add argument $vip for binding important resolver

### DIFF
--- a/src/LocaleResolver.php
+++ b/src/LocaleResolver.php
@@ -39,6 +39,7 @@ class LocaleResolver
 		} else {
 			$this->resolvers[] = $resolver;
 		}
+
 		return $this;
 	}
 

--- a/src/LocaleResolver.php
+++ b/src/LocaleResolver.php
@@ -12,6 +12,9 @@ class LocaleResolver
 	private $container;
 
 	/** @var array<string> */
+	private $primaryResolvers = [];
+
+	/** @var array<string> */
 	private $resolvers = [];
 
 	public function __construct(
@@ -24,21 +27,33 @@ class LocaleResolver
 	/**
 	 * @return array<string>
 	 */
+	public function getPrimaryResolvers(): array
+	{
+		return $this->primaryResolvers;
+	}
+
+	/**
+	 * @return array<string>
+	 */
 	public function getResolvers(): array
 	{
 		return $this->resolvers;
 	}
 
-	public function addResolver(
-		string $resolver,
-		bool $vip = false
+	public function addPrimaryResolver(
+		string $primaryResolver
 	): self
 	{
-		if ($vip === true) {
-			array_unshift($this->resolvers, $resolver);
-		} else {
-			$this->resolvers[] = $resolver;
-		}
+		$this->primaryResolvers[] = $primaryResolver;
+
+		return $this;
+	}
+
+	public function addResolver(
+		string $resolver
+	): self
+	{
+		$this->resolvers[] = $resolver;
 
 		return $this;
 	}
@@ -47,7 +62,7 @@ class LocaleResolver
 		Translator $translator
 	): string
 	{
-		foreach ($this->resolvers as $v1) {
+		foreach (array_merge($this->primaryResolvers, $this->resolvers) as $v1) {
 			/** @var \Contributte\Translation\LocalesResolvers\ResolverInterface $resolver */
 			$resolver = $this->container->getByType($v1);
 			$locale = $resolver->resolve($translator);

--- a/src/LocaleResolver.php
+++ b/src/LocaleResolver.php
@@ -30,10 +30,15 @@ class LocaleResolver
 	}
 
 	public function addResolver(
-		string $resolver
+		string $resolver,
+		bool $vip = false
 	): self
 	{
-		$this->resolvers[] = $resolver;
+		if ($vip === true) {
+			array_unshift($this->resolvers, $resolver);
+		} else {
+			$this->resolvers[] = $resolver;
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
Hello, I want to integrate the native bridge of this package to my Localization package: https://github.com/baraja-core/localization

When the user defines a simple extension to the project neon file, I won't to rewrite the default `LocaleResolver` by my custom DI extension.

Current behavior:

![Snímek obrazovky 2021-03-15 v 18 30 43](https://user-images.githubusercontent.com/4738758/111196143-4356b080-85bd-11eb-9c25-25822779753e.png)

Expected result:

![Snímek obrazovky 2021-03-15 v 18 39 04](https://user-images.githubusercontent.com/4738758/111196603-c4ae4300-85bd-11eb-940b-2441df6cb405.png)

In my bridge code it can be implemented like this:

![Snímek obrazovky 2021-03-15 v 18 36 28](https://user-images.githubusercontent.com/4738758/111196253-5c5f6180-85bd-11eb-8d58-d86f979277dd.png)

What do you think about it?