### PR TITLE
[BUG] Translator: LocaleResolver must be called automatically in constructor.

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -70,7 +70,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 		$this->cacheDir = $cacheDir;
 		$this->debug = $debug;
 
-		parent::__construct('', null, $cacheDir, $debug, $cacheVary);
+		parent::__construct($localeResolver->resolve($this), null, $cacheDir, $debug, $cacheVary);
 	}
 
 	public function getLocaleResolver(): LocaleResolver


### PR DESCRIPTION
The new version of the library has strange behaviour and cannot automatically detect the language at all. It displays a completely different language to users, even if Czech has been correctly detected.

The only solution is to recognize the language in the constructor.

Example of behaviour:

![Snímek obrazovky 2021-07-28 v 14 23 58](https://user-images.githubusercontent.com/4738758/127322012-2542d57e-4173-4a55-ac50-1a41a5ad2d4a.png)

Thanks.