### PR TITLE
Docs update - fallback value note

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -48,6 +48,7 @@ translation:
 		- %appDir%/lang
 	returnOriginalMessage: true # to not translate undefined messages, default is false
 ```
+Note: The `fallback` configuration values should always reflect the **locale code** used in the file you wish to _fallback_ to (e.g. `en_US` for `messages.en_US.neon`, or `en` for `messages.en.neon`).
 
 ### Locale resolvers
 


### PR DESCRIPTION
Added a note for fallback configuration value to prevent confusion when fallback seemingly does not work, when "short locale code" is used for fallback and "long locale code" is used for the dictionary neon file.