### PR TITLE
Latte 3 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,6 +74,15 @@ jobs:
     name: "Static analysis"
     runs-on: "ubuntu-latest"
 
+    strategy:
+      matrix:
+        composer-args: [ "" ]
+        command: [ "phpstan" ]
+        include:
+          - composer-args: "--prefer-lowest"
+            command: "phpstan-lowest"
+      fail-fast: false
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -115,10 +124,10 @@ jobs:
           restore-keys: "${{ runner.os }}-composer-"
 
       - name: "Install dependencies"
-        run: "${{ env.composer-install }}"
+        run: "${{ env.composer-install }} ${{ matrix.composer-args }}"
 
       - name: "PHPStan"
-        run: "make phpstan"
+        run: "make ${{ matrix.command}}"
 
   tests:
     name: "Tests"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ csf: vendor
 phpstan: vendor
 	vendor/bin/phpstan analyse -l max -c phpstan.neon src
 
+phpstan-lowest: vendor
+	vendor/bin/phpstan analyse -l max -c phpstan.lowest.neon src
+
 tests: vendor
 	vendor/bin/tester -s -p php --colors 1 -C tests/Tests
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": "^8.0.2",
-    "latte/latte": "^2.6",
+    "latte/latte": "^2.6|^3.0",
     "nette/di": "^3.0.6",
     "nette/finder": "^2.5.2",
     "nette/http": "^3.0",
@@ -37,7 +37,7 @@
     "nette/tester": "^2.3.1",
     "ninjify/nunjuck": "^0.3.0",
     "ninjify/qa": "^0.13",
-    "phpstan/phpstan": "^1.4",
+    "phpstan/phpstan": "^1.8",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-nette": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.1",
@@ -55,7 +55,10 @@
     }
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "extra": {
     "branch-alias": {

--- a/phpstan.lowest.neon
+++ b/phpstan.lowest.neon
@@ -10,39 +10,17 @@ parameters:
 		- src
 		- tests
 	excludePaths:
-		- src/Latte/Filters.php
-		- src/Latte/Macros.php
+		- src/Latte/TranslatorExtension.php
+		- src/Latte/Nodes/*
 	ignoreErrors:
 		-
 			count: 2
 			message: '#^Variable property access on object\.$#'
 			path: 'src/Loaders/Doctrine.php'
 
-		-
-			count: 2
-			message: '#^Comparison operation "\<" between \d+ and \d+ is always false\.$#'
-			path: 'src/Latte/Macros.php'
-
-		-
-			count: 1
-			message: '#^Comparison operation "\>=" between \d+ and \d+ is always true\.$#'
-			path: 'src/Latte/Macros.php'
-
-		-
-			count: 1
-			message: '#^Result of && is always false\.$#'
-			path: 'src/Latte/Macros.php'
-
 		# -------------------------------------------------------------------
 		# for back compatibility with old packages - will be remove in future
 		# -------------------------------------------------------------------
-		-
-			message: """
-				#^Fetching class constant class of deprecated class Nette\\\\Bridges\\\\ApplicationLatte\\\\ILatteFactory\\:
-				use Nette\\\\Bridges\\\\ApplicationLatte\\\\LatteFactory$#
-			"""
-			count: 1
-			path: src/DI/TranslationExtension.php
 
 		-
 			message: """
@@ -57,6 +35,13 @@ parameters:
 			message: """
 				#^Parameter \\$translator of method Contributte\\\\Translation\\\\Latte\\\\Filters\\:\\:__construct\\(\\) has typehint with deprecated interface Nette\\\\Localization\\\\ITranslator\\:
 				use Nette\\\\Localization\\\\Translator$#
+			"""
+			path: src/Latte/Filters.php
+
+		-
+			count: 1
+			message: """
+				#^Call to an undefined method Nette\\\\Localization\\\\ITranslator::translate\\(\\)#
 			"""
 			path: src/Latte/Filters.php
 
@@ -84,10 +69,3 @@ parameters:
 			"""
 			path: src/Translator.php
 
-		-
-			message: """
-				#^Instantiation of deprecated class Nette\\\\PhpGenerator\\\\PhpLiteral\\:
-				use Nette\\\\PhpGenerator\\\\Literal$#
-			"""
-			count: 1
-			path: src/DI/TranslationExtension.php

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -2,7 +2,6 @@
 
 namespace Contributte\Translation;
 
-use Latte\MacroNode;
 use Nette\Utils\Strings;
 
 class Helpers
@@ -38,15 +37,6 @@ class Helpers
 		return [$domain, $message];
 	}
 
-	public static function macroWithoutParameters(
-		MacroNode $node
-	): bool
-	{
-		$result = Strings::trim($node->tokenizer->joinUntil(',')) === Strings::trim($node->args);
-		$node->tokenizer->reset();
-		return $result;
-	}
-
 	public static function isAbsoluteMessage(
 		string $message
 	): bool
@@ -54,11 +44,28 @@ class Helpers
 		return Strings::startsWith($message, '//');
 	}
 
+	/**
+	 * @param mixed $message
+	 * @param array<string>|null $prefix
+	 * @return mixed
+	 */
+	public static function prefixMessage(
+		$message,
+		?array $prefix
+	)
+	{
+		if (is_string($message) && $prefix !== null && !self::isAbsoluteMessage($message)) {
+			$message = implode('.', $prefix) . '.' . $message;
+		}
+
+		return $message;
+	}
+
 	public static function createLatteProperty(
 		string $suffix
 	): string
 	{
-		return '$ʟ_contributteTranslation' . $suffix;
+		return '$ᴛ_contributteTranslation' . $suffix;
 	}
 
 }

--- a/src/Latte/Macros.php
+++ b/src/Latte/Macros.php
@@ -9,6 +9,7 @@ use Latte\Engine;
 use Latte\MacroNode;
 use Latte\Macros\MacroSet;
 use Latte\PhpWriter;
+use Nette\Utils\Strings;
 
 class Macros extends MacroSet
 {
@@ -50,8 +51,10 @@ class Macros extends MacroSet
 				$value = 'ob_get_clean()';
 			}
 
+			/** @phpstan-ignore-next-line */
 			if (!defined(Engine::class . '::VERSION_ID') || Engine::VERSION_ID < 20900) {
 				$latteProp = '$_fi';
+			/** @phpstan-ignore-next-line */
 			} elseif (Engine::VERSION_ID >= 20900 && Engine::VERSION_ID < 20902) {
 				$latteProp = '$__fi';
 			} else {
@@ -65,7 +68,7 @@ class Macros extends MacroSet
 			$messageProp = Helpers::createLatteProperty('Message');
 			$prefixProp = Helpers::createLatteProperty('Prefix');
 
-			$macroCodeEcho = Helpers::macroWithoutParameters($node)
+			$macroCodeEcho = self::macroWithoutParameters($node)
 				? sprintf('echo %%modify(call_user_func($this->filters->translate, %s))', $messageProp)
 				: sprintf('echo %%modify(call_user_func($this->filters->translate, %s, %%node.args))', $messageProp);
 
@@ -119,6 +122,15 @@ class Macros extends MacroSet
 
 			%s = [%%node.word];
 		', $tempPrefixProp, $tempPrefixProp, $prefixProp, $tempPrefixProp, $prefixProp, $prefixProp));
+	}
+
+	public static function macroWithoutParameters(
+		MacroNode $node
+	): bool
+	{
+		$result = Strings::trim($node->tokenizer->joinUntil(',')) === Strings::trim($node->args);
+		$node->tokenizer->reset();
+		return $result;
 	}
 
 }

--- a/src/Latte/Nodes/TranslateNode.php
+++ b/src/Latte/Nodes/TranslateNode.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Latte\Nodes;
+
+use Latte\Compiler\NodeHelpers;
+use Latte\Compiler\Nodes\AreaNode;
+use Latte\Compiler\Nodes\NopNode;
+use Latte\Compiler\Nodes\Php;
+use Latte\Compiler\Nodes\Php\ModifierNode;
+use Latte\Compiler\Nodes\StatementNode;
+use Latte\Compiler\Nodes\TextNode;
+use Latte\Compiler\PrintContext;
+use Latte\Compiler\Tag;
+
+class TranslateNode extends StatementNode
+{
+
+	public AreaNode $content;
+
+	public ModifierNode $modifier;
+
+	/** @return \Generator<int, ?array<mixed>, array{AreaNode, ?Tag}, TranslateNode|NopNode> */
+	public static function create(
+		Tag $tag
+	): \Generator
+	{
+		$tag->outputMode = $tag::OutputKeepIndentation;
+
+		$node = new TranslateNode();
+		$args = $tag->parser->parseArguments();
+		$node->modifier = $tag->parser->parseModifier();
+		$node->modifier->escape = true;
+		if ($tag->void) {
+			return new NopNode();
+		}
+
+		[$node->content] = yield;
+
+		if (($text = NodeHelpers::toText($node->content)) !== null) {
+			$node->content = new TextNode($text);
+		}
+
+		array_unshift($node->modifier->filters, new Php\FilterNode(new Php\IdentifierNode('translate'), $args->toArguments()));
+
+		return $node;
+	}
+
+
+	public function print(
+		PrintContext $context
+	): string
+	{
+		if ($this->content instanceof TextNode) {
+			return $context->format(
+				'
+					$ʟ_fi = new LR\FilterInfo(%dump);
+					echo %modifyContent(%dump) %line;
+				',
+				$context->getEscaper()->export(),
+				$this->modifier,
+				$this->content->content,
+				$this->position,
+			);
+
+		} else {
+			return $context->format(
+				'
+					ob_start(fn() => ""); try {
+						%node
+					} finally {
+						$ʟ_tmp = ob_get_clean();
+					}
+					$ʟ_fi = new LR\FilterInfo(%dump);
+					echo %modifyContent($ʟ_tmp) %line;
+				',
+				$this->content,
+				$context->getEscaper()->export(),
+				$this->modifier,
+				$this->position,
+			);
+		}
+	}
+
+
+	public function &getIterator(): \Generator
+	{
+		yield $this->content;
+		yield $this->modifier;
+	}
+
+}

--- a/src/Latte/Nodes/TranslatorNode.php
+++ b/src/Latte/Nodes/TranslatorNode.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Latte\Nodes;
+
+use Contributte\Translation\Helpers;
+use Latte\Compiler\Nodes\AreaNode;
+use Latte\Compiler\Nodes\Php\ExpressionNode;
+use Latte\Compiler\Nodes\StatementNode;
+use Latte\Compiler\PrintContext;
+use Latte\Compiler\Tag;
+
+class TranslatorNode extends StatementNode
+{
+
+	public ExpressionNode $prefix;
+
+	public AreaNode $content;
+
+	/** @return \Generator<int, ?array<mixed>, array{AreaNode, ?Tag}, TranslatorNode> */
+	public static function create(
+		Tag $tag
+	): \Generator
+	{
+		$tag->expectArguments();
+		$variable = $tag->parser->parseUnquotedStringOrExpression();
+
+		$node = new TranslatorNode();
+		$node->prefix = $variable;
+		[$node->content] = yield;
+		return $node;
+	}
+
+
+	public function print(
+		PrintContext $context
+	): string
+	{
+		$prefixProp = Helpers::createLatteProperty('Prefix');
+		$tempPrefixProp = Helpers::createLatteProperty('TempPrefix');
+
+		return $context->format(
+			sprintf('
+			%s = %s ?? [] %%line;
+			array_push(%s, %s ?? null);
+			%s = [%%node];
+
+			%%node
+
+			%s = array_pop(%s);
+			', $tempPrefixProp, $tempPrefixProp, $tempPrefixProp, $prefixProp, $prefixProp, $prefixProp, $tempPrefixProp),
+			$this->position,
+			$this->prefix,
+			$this->content
+		);
+	}
+
+
+	public function &getIterator(): \Generator
+	{
+		yield $this->prefix;
+		yield $this->content;
+	}
+
+}

--- a/src/Latte/TranslatorExtension.php
+++ b/src/Latte/TranslatorExtension.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Latte;
+
+use Contributte\Translation\Helpers;
+use Contributte\Translation\Latte\Nodes\TranslateNode;
+use Contributte\Translation\Latte\Nodes\TranslatorNode;
+use Latte\Compiler\Node;
+use Latte\Compiler\Nodes\Php\ArgumentNode;
+use Latte\Compiler\Nodes\Php\Expression\ArrayNode;
+use Latte\Compiler\Nodes\Php\Expression\BinaryOpNode;
+use Latte\Compiler\Nodes\Php\Expression\StaticCallNode;
+use Latte\Compiler\Nodes\Php\Expression\VariableNode;
+use Latte\Compiler\Nodes\Php\FilterNode;
+use Latte\Compiler\Nodes\Php\IdentifierNode;
+use Latte\Compiler\Nodes\Php\NameNode;
+use Latte\Compiler\Nodes\Php\Scalar\NullNode;
+use Latte\Compiler\Tag;
+use Latte\Essential\Nodes\PrintNode;
+use Latte\Extension;
+use Latte\Runtime\FilterInfo;
+use Nette\Localization\ITranslator;
+
+class TranslatorExtension extends Extension
+{
+
+	private ITranslator $translator;
+
+	public function __construct(
+		ITranslator $translator
+	)
+	{
+		$this->translator = $translator;
+	}
+
+	public function getTags(): array
+	{
+		return [
+			'_' => [$this, 'parseTranslate'],
+			'translate' => [TranslateNode::class, 'create'],
+			'translator' => [TranslatorNode::class, 'create'],
+		];
+	}
+
+	public function getFilters(): array
+	{
+		return [
+			'translate' => fn(FilterInfo $fi, ...$args): string => $this->translator->translate(...$args),
+		];
+	}
+
+	public function getProviders(): array
+	{
+		return [
+			'translator' => $this->translator,
+		];
+	}
+
+	public function parseTranslate(
+		Tag $tag
+	): Node
+	{
+		$tag->outputMode = $tag::OutputKeepIndentation;
+		$tag->expectArguments();
+		$expression = $tag->parser->parseUnquotedStringOrExpression();
+		$args = new ArrayNode();
+		if ($tag->parser->stream->tryConsume(',') !== null) {
+			$args = $tag->parser->parseArguments();
+		}
+
+		$prefixProp = Helpers::createLatteProperty('Prefix');
+
+		$messageNode = new StaticCallNode(
+			new NameNode('\Contributte\Translation\Helpers', NameNode::KindFullyQualified),
+			new IdentifierNode('prefixMessage'),
+			[
+				new ArgumentNode($expression),
+				new ArgumentNode(new BinaryOpNode(new VariableNode(substr($prefixProp, 1)), '??', new NullNode())),
+			]
+		);
+
+		$outputNode = new PrintNode();
+		$outputNode->modifier = $tag->parser->parseModifier();
+		$outputNode->modifier->escape = true;
+		$outputNode->expression = $messageNode;
+		array_unshift($outputNode->modifier->filters, new FilterNode(new IdentifierNode('translate'), $args->toArguments()));
+		return $outputNode;
+	}
+
+}

--- a/tests/Tests/TranslatorTest.phpt
+++ b/tests/Tests/TranslatorTest.phpt
@@ -230,18 +230,12 @@ final class TranslatorTest extends TestAbstract
 		$translator = $container->getByType(ITranslator::class);
 
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{_messages.hello}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}messages.hello{/_}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "messages.hello"}{$message}{/_}')));
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{php $message = "messages.hello"}{$message|translate}')));
 
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{_hello}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}hello{/_}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "hello"}{$message}{/_}')));
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{php $message = "hello"}{$message|translate}')));
 
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{_//messages.hello}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}//messages.hello{/_}')));
-		Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "//messages.hello"}{$message}{/_}')));
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{php $message = "//messages.hello"}{$message|translate}')));
 
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{_hello, [], messages, en}')));
@@ -249,6 +243,26 @@ final class TranslatorTest extends TestAbstract
 
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{_hello, null, [], messages, en}')));
 		Assert::same('Hello', $latte->renderToString(FileMock::create('{php $message = "hello"}{$message|translate: null, [], messages, en}')));
+
+		if (version_compare(\Latte\Engine::VERSION, '3', '<')) {
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}messages.hello{/_}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "messages.hello"}{$message}{/_}')));
+
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}hello{/_}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "hello"}{$message}{/_}')));
+
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}//messages.hello{/_}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{_}{php $message = "//messages.hello"}{$message}{/_}')));
+		} else {
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}messages.hello{/translate}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}{php $message = "messages.hello"}{$message}{/translate}')));
+
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}hello{/translate}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}{php $message = "hello"}{$message}{/translate}')));
+
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}//messages.hello{/translate}')));
+			Assert::same('Hello', $latte->renderToString(FileMock::create('{translate}{php $message = "//messages.hello"}{$message}{/translate}')));
+		}
 
 		Assert::same('Hi Ales!', $latte->renderToString(FileMock::create('{_messages.hi, [name => Ales]}')));
 		Assert::same('Hi Ales!', $latte->renderToString(FileMock::create('{php $message = "messages.hi"}{$message|translate: [name => Ales]}')));


### PR DESCRIPTION
- added support for Latte 3 (`Latte\TranslatorExtension`)
- compatibility with Latte 2 maintained
- with Latte 3 it is not possible to use pair `{_}{/_}` replaced with `{translate}{/translate}` (same as with Latte default translator)
- simplified generated PHP code from tags
- added PHPStan checks for lowest dependencies
- latte temp variables uses prefix `$ᴛ_` (Because Latte 3 forbids prefix `$ʟ_`)