### PR TITLE
Passing locale parameter to getCatalogue method

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -355,7 +355,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 
 		if ($id !== null) {
 			if ($this->psrLogger !== null) {
-				if (!$this->getCatalogue()->has($id, $domain)) {
+				if (!$this->getCatalogue($locale)->has($id, $domain)) {
 					$this->psrLogger
 						->notice(
 							'Missing translation',
@@ -369,7 +369,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 			}
 
 			if ($this->tracyPanel !== null) {
-				if (!$this->getCatalogue()->has($id, $domain)) {
+				if (!$this->getCatalogue($locale)->has($id, $domain)) {
 					$this->tracyPanel
 						->addMissingTranslation($id, $domain);
 				}


### PR DESCRIPTION
Missing passing the `$locale` parameter to the `getCatalogue` method.