### PR TITLE
feat: nette/latte translations extractor WIP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,12 @@
     "nette/finder": "^2.5.2",
     "nette/http": "^3.0",
     "nette/neon": "^3.3.1",
-    "nette/schema": "^1.0",
     "nette/routing": "^3.0",
+    "nette/schema": "^1.0",
     "nette/utils": "^3.2.1",
-    "symfony/translation": "^5.0",
-    "symfony/config": "^5.0"
+    "symfony/config": "^5.0",
+    "symfony/finder": "^5.4",
+    "symfony/translation": "^5.0"
   },
   "require-dev": {
     "doctrine/orm": "^2.8",

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Command;
+
+use Contributte\Translation\Extractor\LatteExtractor;
+use Contributte\Translation\Extractor\NetteExtractor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\Catalogue\TargetOperation;
+use Symfony\Component\Translation\Dumper\PoFileDumper;
+use Symfony\Component\Translation\Extractor\ChainExtractor;
+use Symfony\Component\Translation\Loader\PoFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Reader\TranslationReader;
+use Symfony\Component\Translation\Writer\TranslationWriter;
+
+class ExtractCommand extends Command
+{
+
+	protected static $defaultName = 'translation:extract';
+
+	protected static $defaultDescription = 'Extract missing translations keys from code to translation files.';
+
+	protected function configure(): void
+	{
+		$this
+			->setDefinition([
+				new InputArgument('locale', InputArgument::REQUIRED, 'The locale'),
+				new InputOption('scan-dir', 'd', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory where to load the messages.'),
+				new InputOption('output-dir', 'o', InputOption::VALUE_OPTIONAL, 'Directory to write the messages to.'),
+				new InputOption('clean', null, InputOption::VALUE_NONE, 'Should clean not found messages'),
+			])
+			->setName(self::$defaultName)
+			->setDescription(self::$defaultDescription);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$extractor = new ChainExtractor();
+		$extractor->addExtractor('php', new NetteExtractor());
+		$extractor->addExtractor('latte', new LatteExtractor());
+
+		$reader = new TranslationReader();
+		$reader->addLoader('po', new PoFileLoader());
+
+		$scanDirectory = $input->getOption('scan-dir');
+		$outputDirectory = $input->getOption('output-dir');
+
+		$currentCatalogue = new MessageCatalogue($input->getArgument('locale'));
+		$reader->read($outputDirectory, $currentCatalogue);
+
+		$extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
+
+		foreach ($scanDirectory as $directory) {
+			$extractor->extract($directory, $extractedCatalogue);
+		}
+
+		$operation = $input->getOption('clean')
+			? new TargetOperation($currentCatalogue, $extractedCatalogue)
+			: new MergeOperation($currentCatalogue, $extractedCatalogue);
+
+		$operation->moveMessagesToIntlDomainsIfPossible($operation::NEW_BATCH);
+
+		$writer = new TranslationWriter();
+		$writer->addDumper('po', new PoFileDumper());
+
+		$writer->write($operation->getResult(), 'po', ['path' => $outputDirectory]);
+
+		return 0;
+	}
+
+}

--- a/src/Extractor/LatteExtractor.php
+++ b/src/Extractor/LatteExtractor.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Extractor;
+
+use Latte\MacroTokens;
+use Latte\Parser;
+use Latte\PhpWriter;
+use Latte\Token;
+use LogicException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\Extractor\AbstractFileExtractor;
+use Symfony\Component\Translation\Extractor\ExtractorInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class LatteExtractor extends AbstractFileExtractor implements ExtractorInterface
+{
+
+	private string $prefix = '';
+
+
+	public function extract($resource, MessageCatalogue $catalogue)
+	{
+		$files = $this->extractFiles($resource);
+
+		foreach ($files as $file) {
+			$this->extractFile((string) $file, $catalogue);
+		}
+	}
+
+	public function setPrefix(string $prefix)
+	{
+		$this->prefix = $prefix;
+	}
+
+	protected function canBeExtracted(string $file)
+	{
+		return $this->isFile($file) && in_array(pathinfo($file, \PATHINFO_EXTENSION), ['latte', 'phtml'], true);
+	}
+
+	protected function extractFromDirectory($directory)
+	{
+		if (!class_exists(Finder::class)) {
+			throw new LogicException(sprintf('You cannot use "%s" as the "symfony/finder" package is not installed. Try running "composer require symfony/finder".', static::class));
+		}
+
+		$finder = new Finder();
+
+		return $finder->files()->name(['*.latte', '*.phtml'])->in($directory);
+
+	}
+
+	protected function extractFile(string $file, MessageCatalogue $catalogue): void
+	{
+		$parser = new Parser();
+
+		foreach ($parser->parse(file_get_contents($file)) as $token) {
+			if ($token->type !== Token::MACRO_TAG) {
+				continue;
+			}
+
+			if ($token->name !== '_') {
+				continue;
+			}
+
+			$args = new MacroTokens($token->value);
+			$writer = new PhpWriter($args, $token->modifiers);
+
+			$message = $writer->write('%node.word');
+
+			if (in_array(substr(trim($message), 0, 1), ['"', '\''], TRUE)) {
+				$message = substr(trim($message), 1, -1);
+			} elseif (substr(trim($message), 0, 1) === '(') {
+				$message = substr(trim($message), 2, -2);
+			}
+
+			$catalogue->set(($this->prefix !== '' ? $this->prefix . '.' : '') . $message, $message);
+		}
+	}
+
+}

--- a/src/Extractor/NetteExtractor.php
+++ b/src/Extractor/NetteExtractor.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Translation\Extractor;
+
+use Symfony\Component\Translation\Extractor\PhpExtractor;
+
+class NetteExtractor extends PhpExtractor
+{
+
+	protected $sequences = [
+		['->', 'translate', '(', self::MESSAGE_TOKEN],
+		['->', 'addButton', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addCheckbox', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addCheckboxList', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addEmail', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addError', '(', self::MESSAGE_TOKEN],
+		['->', 'addGroup', '(', self::MESSAGE_TOKEN],
+		['->', 'addImageButton', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addInteger', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addMultiSelect', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addMultiUpload', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addPassword', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addProtection', '(', self::MESSAGE_TOKEN],
+		['->', 'addRadioList', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addSelect', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addSubmit', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addText', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addTextArea', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addUpload', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'addRule', '(', self::METHOD_ARGUMENTS_TOKEN, ',', self::MESSAGE_TOKEN],
+		['->', 'setRequired', '(', self::MESSAGE_TOKEN],
+		['->', 'setDefaultValue', '(', self::MESSAGE_TOKEN],
+		['->', 'setPrompt', '(', self::MESSAGE_TOKEN],
+	];
+
+}


### PR DESCRIPTION
Hi, are you interested in Nette and Latte translations extractor, based on https://symfony.com/doc/current/translation.html#extracting-translation-contents-and-updating-catalogs-automatically
inspired by kdyby/translation

currently, proof of concept.

usage

```neon
services:
	- Contributte\Translation\Command\ExtractCommand
```

```bash
php bin/console translation:extract cs -d app -o locale --clean
```

TODO:
- setup writers and loaders from config
- setup default source and target directory from config
- neon writer