### PR TITLE
Support symfony/translation 7 & symfony/config 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "nette/schema": "^1.0",
     "nette/routing": "^3.0",
     "nette/utils": "^3.2.1|~4.0.0",
-    "symfony/translation": "^6.0",
-    "symfony/config": "^6.0"
+    "symfony/translation": "^6.0|^7.0",
+    "symfony/config": "^6.0|^7.0"
   },
   "require-dev": {
     "doctrine/orm": "^2.8",


### PR DESCRIPTION
Let's see if tests will fail or not.

- The PHPStan test failure seems unrelated. Happens because a class has been renamed in Latte 3.0.12: "StaticCallNode renamed to StaticMethodCallNode" https://github.com/nette/latte/releases/tag/v3.0.12
- The Quality assurance issue is also unrelated to the change here
- Both fixed by #125