### PR TITLE
Use contributte/qa and fix build QA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ vendor: composer.json composer.lock
 qa: lint phpstan cs
 
 lint: vendor
-	vendor/bin/linter src tests
+	vendor/bin/parallel-lint src tests
 
 cs: vendor
 	vendor/bin/codesniffer src tests

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require-dev": {
     "contributte/qa": "^0.2.0",
     "doctrine/orm": "^2.8",
-    "mockery/mockery": "^1.4",
+    "mockery/mockery": "^1.5",
     "nette/application": "^3.1.0",
     "nette/bootstrap": "^3.0",
     "nette/database": "^3.1.1",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "symfony/config": "^6.0"
   },
   "require-dev": {
+    "contributte/qa": "^0.2.0",
     "doctrine/orm": "^2.8",
     "mockery/mockery": "^1.4",
     "nette/application": "^3.1.0",
@@ -36,7 +37,7 @@
     "nette/robot-loader": "^3.4.0|~4.0.0",
     "nette/tester": "^2.3.1",
     "ninjify/nunjuck": "^0.3.0",
-    "ninjify/qa": "^0.13",
+    "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpstan/phpstan": "^1.8",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-nette": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -63,14 +63,6 @@ parameters:
 		-
 			count: 1
 			message: """
-				#^Parameter \\$translator of method Contributte\\\\Translation\\\\Latte\\\\TranslatorExtension\\:\\:__construct\\(\\) has typehint with deprecated interface Nette\\\\Localization\\\\ITranslator\\:
-				use Nette\\\\Localization\\\\Translator$#
-			"""
-			path: src/Latte/TranslatorExtension.php
-
-		-
-			count: 1
-			message: """
 				#^Class Contributte\\\\Translation\\\\PrefixedTranslator implements deprecated interface Nette\\\\Localization\\\\ITranslator\\:
 				use Nette\\\\Localization\\\\Translator$#
 			"""

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,8 @@ parameters:
 	excludePaths:
 		- src/Latte/Filters.php
 		- src/Latte/Macros.php
+	bootstrapFiles:
+		- vendor/latte/latte/src/Latte/Compiler/Nodes/Php/Expression/StaticMethodCallNode.php
 	ignoreErrors:
 		-
 			count: 2

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -24,4 +24,8 @@
 			</property>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.PHP.DisallowReference.DisallowedReturningReference">
+		<exclude-pattern>src/Latte/Nodes/TranslateNode.php</exclude-pattern>
+		<exclude-pattern>src/Latte/Nodes/TranslatorNode.php</exclude-pattern>
+	</rule>
 </ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="./vendor/ninjify/coding-standard/contributte.xml">
+	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml">
 		<exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousSuffix" />
 		<exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
 		<exclude name="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature.RequiredMultiLineSignature" />

--- a/src/FallbackResolver.php
+++ b/src/FallbackResolver.php
@@ -18,6 +18,7 @@ class FallbackResolver
 	): self
 	{
 		$this->fallbackLocales = $array;
+
 		return $this;
 	}
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -43,14 +43,12 @@ class Helpers
 	}
 
 	/**
-	 * @param mixed $message
 	 * @param array<string>|null $prefix
-	 * @return mixed
 	 */
 	public static function prefixMessage(
-		$message,
+		mixed $message,
 		?array $prefix
-	)
+	): mixed
 	{
 		if (is_string($message) && $prefix !== null && !self::isAbsoluteMessage($message)) {
 			$message = implode('.', $prefix) . '.' . $message;

--- a/src/Latte/Filters.php
+++ b/src/Latte/Filters.php
@@ -17,15 +17,10 @@ class Filters
 		$this->translator = $translator;
 	}
 
-	/**
-	 * @param \Latte\Runtime\FilterInfo $filterInfo
-	 * @param mixed $message
-	 * @param mixed ...$parameters
-	 */
 	public function translate(
 		FilterInfo $filterInfo,
-		$message,
-		...$parameters
+		mixed $message,
+		mixed ...$parameters
 	): string
 	{
 		return $this->translator->translate($message, ...$parameters);

--- a/src/Latte/Macros.php
+++ b/src/Latte/Macros.php
@@ -21,16 +21,6 @@ class Macros extends MacroSet
 		parent::__construct($compiler);
 	}
 
-	public static function install(
-		Compiler $compiler
-	): void
-	{
-		$me = new static($compiler);
-
-		$me->addMacro('_', [$me, 'macroTranslate'], [$me, 'macroTranslate']);
-		$me->addMacro('translator', [$me, 'macroPrefix'], [$me, 'macroPrefix']);
-	}
-
 	/**
 	 * {_ ...}
 	 *
@@ -124,12 +114,23 @@ class Macros extends MacroSet
 		', $tempPrefixProp, $tempPrefixProp, $prefixProp, $tempPrefixProp, $prefixProp, $prefixProp));
 	}
 
+	public static function install(
+		Compiler $compiler
+	): void
+	{
+		$me = new static($compiler);
+
+		$me->addMacro('_', [$me, 'macroTranslate'], [$me, 'macroTranslate']);
+		$me->addMacro('translator', [$me, 'macroPrefix'], [$me, 'macroPrefix']);
+	}
+
 	public static function macroWithoutParameters(
 		MacroNode $node
 	): bool
 	{
 		$result = Strings::trim($node->tokenizer->joinUntil(',')) === Strings::trim($node->args);
 		$node->tokenizer->reset();
+
 		return $result;
 	}
 

--- a/src/Latte/Nodes/TranslatorNode.php
+++ b/src/Latte/Nodes/TranslatorNode.php
@@ -16,21 +16,6 @@ class TranslatorNode extends StatementNode
 
 	public AreaNode $content;
 
-	/** @return \Generator<int, ?array<mixed>, array{AreaNode, ?Tag}, TranslatorNode> */
-	public static function create(
-		Tag $tag
-	): \Generator
-	{
-		$tag->expectArguments();
-		$variable = $tag->parser->parseUnquotedStringOrExpression();
-
-		$node = new TranslatorNode();
-		$node->prefix = $variable;
-		[$node->content] = yield;
-		return $node;
-	}
-
-
 	public function print(
 		PrintContext $context
 	): string
@@ -54,11 +39,25 @@ class TranslatorNode extends StatementNode
 		);
 	}
 
-
 	public function &getIterator(): \Generator
 	{
 		yield $this->prefix;
 		yield $this->content;
+	}
+
+	/** @return \Generator<int, ?array<mixed>, array{AreaNode, ?Tag}, TranslatorNode> */
+	public static function create(
+		Tag $tag
+	): \Generator
+	{
+		$tag->expectArguments();
+		$variable = $tag->parser->parseUnquotedStringOrExpression();
+
+		$node = new TranslatorNode();
+		$node->prefix = $variable;
+		[$node->content] = yield;
+
+		return $node;
 	}
 
 }

--- a/src/Latte/TranslatorExtension.php
+++ b/src/Latte/TranslatorExtension.php
@@ -19,20 +19,23 @@ use Latte\Compiler\Tag;
 use Latte\Essential\Nodes\PrintNode;
 use Latte\Extension;
 use Latte\Runtime\FilterInfo;
-use Nette\Localization\ITranslator;
+use Nette\Localization\Translator;
 
 class TranslatorExtension extends Extension
 {
 
-	private ITranslator $translator;
+	private Translator $translator;
 
 	public function __construct(
-		ITranslator $translator
+		Translator $translator
 	)
 	{
 		$this->translator = $translator;
 	}
 
+	/**
+	 * @return array{_:callable(Tag):Node, translate:callable(Tag):\Generator, translator:callable(Tag):\Generator}
+	 */
 	public function getTags(): array
 	{
 		return [
@@ -42,13 +45,19 @@ class TranslatorExtension extends Extension
 		];
 	}
 
+	/**
+	 * @return array{translate:callable(FilterInfo $fi, string ...$args):string}
+	 */
 	public function getFilters(): array
 	{
 		return [
-			'translate' => fn(FilterInfo $fi, ...$args): string => (string) $this->translator->translate(...$args),
+			'translate' => fn (FilterInfo $fi, ...$args): string => (string) $this->translator->translate(...$args),
 		];
 	}
 
+	/**
+	 * @return array{translator:Translator}
+	 */
 	public function getProviders(): array
 	{
 		return [
@@ -84,6 +93,7 @@ class TranslatorExtension extends Extension
 		$outputNode->modifier->escape = true;
 		$outputNode->expression = $messageNode;
 		array_unshift($outputNode->modifier->filters, new FilterNode(new IdentifierNode('translate'), $args->toArguments()));
+
 		return $outputNode;
 	}
 

--- a/src/Loaders/DatabaseAbstract.php
+++ b/src/Loaders/DatabaseAbstract.php
@@ -20,6 +20,17 @@ abstract class DatabaseAbstract extends ArrayLoader implements LoaderInterface
 	];
 
 	/**
+	 * @param array{table: string, id: string, locale: string, message: string} $config
+	 * @return array<string>
+	 */
+	abstract protected function getMessages(
+		array $config,
+		string $resource,
+		string $locale,
+		string $domain
+	): array;
+
+	/**
 	 * {@inheritdoc}
 	 *
 	 * @throws \Contributte\Translation\Exceptions\InvalidArgument
@@ -63,16 +74,5 @@ abstract class DatabaseAbstract extends ArrayLoader implements LoaderInterface
 
 		return $catalogue;
 	}
-
-	/**
-	 * @param array{table: string, id: string, locale: string, message: string} $config
-	 * @return array<string>
-	 */
-	abstract protected function getMessages(
-		array $config,
-		string $resource,
-		string $locale,
-		string $domain
-	): array;
 
 }

--- a/src/LocaleResolver.php
+++ b/src/LocaleResolver.php
@@ -30,13 +30,13 @@ class LocaleResolver
 
 	/**
 	 * @param class-string $resolver
-	 * @return self
 	 */
 	public function addResolver(
 		string $resolver
 	): self
 	{
 		$this->resolvers[] = $resolver;
+
 		return $this;
 	}
 

--- a/src/LocalesResolvers/Session.php
+++ b/src/LocalesResolvers/Session.php
@@ -33,6 +33,7 @@ class Session implements ResolverInterface
 	): self
 	{
 		$this->sessionSection[self::$parameter] = $locale;
+
 		return $this;
 	}
 
@@ -42,6 +43,7 @@ class Session implements ResolverInterface
 	{
 		if (!$this->session->isStarted() && $this->httpResponse->isSent()) {
 			trigger_error('The advice of session locale resolver is required but the session has not been started and headers had been already sent. Either start your sessions earlier or disable the SessionResolver.', E_USER_WARNING);
+
 			return null;
 		}
 

--- a/src/PrefixedTranslator.php
+++ b/src/PrefixedTranslator.php
@@ -30,18 +30,15 @@ class PrefixedTranslator implements ITranslator
 		return $this->prefix;
 	}
 
-	/**
-	 * @param mixed $message
-	 * @param mixed ...$parameters
-	 */
 	public function translate(
-		$message,
-		...$parameters
+		mixed $message,
+		mixed ...$parameters
 	): string
 	{
 		$this->translator->addPrefix($this->prefix);
 		$message = $this->translator->translate($message, ...$parameters);
 		$this->translator->removePrefix();
+
 		return $message;
 	}
 

--- a/src/Tracy/Panel.php
+++ b/src/Tracy/Panel.php
@@ -43,6 +43,7 @@ class Panel implements IBarPanel
 		// https://postimg.cc/jC4Nq2wg
 		$icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><g fill-rule="evenodd"><path d="M135 72v23H54l-2 1v13l1 13 68 1h68c1 2 0 10-2 16a98 98 0 0 0-2 6v2l-1 1-1 3c-3 8-7 15-12 21s-14 15-16 15a82 82 0 0 1-16-17l-3-4-3-5-10-17-2-4H94v1l8 19 4 5c5 9 21 29 30 38 2 2 2 2 0 4a570 570 0 0 1-59 40c-4 3-5 2 3 13s6 11 13 6l5-2a345 345 0 0 0 16-10 480 480 0 0 0 39-26c3-2 2-3 7 1a300 300 0 0 0 47 34c6 3 6 2 5 4a273 273 0 0 1-11 30l-1 2-1 2a977 977 0 0 1-9 26h24v-1l1-2a128 128 0 0 1 5-13l2-5a339 339 0 0 0 11-31h70l1 3a653 653 0 0 0 17 48l1 1h25l-4-13a174 174 0 0 1-6-17l-2-5a1344 1344 0 0 0-30-82 38 38 0 0 1-2-5l-2-5v-1l-1-2-2-6v-2h-1v-2l-1-2-1-3-1-3a454 454 0 0 1-11-29l-27 1-1 3a402 402 0 0 1-3 8l-1 3a168 168 0 0 1-5 12 201 201 0 0 0-7 19 157 157 0 0 1-6 15l-1 2v2a94 94 0 0 0-5 11l-1 5c-4 10-4 9-7 7a202 202 0 0 1-42-33l2-3a120 120 0 0 0 19-25 176 176 0 0 0 20-54h13l13-1V96l-39-1h-39V71l-31 1m135 110a733 733 0 0 1 21 58l4 14-27 1c-30 0-28 0-27-3a635 635 0 0 0 23-61v-3l1-2a52 52 0 0 1 3-7v-1l2 4" fill="#f9fafb"/><path d="m14 14-2 2v368l2 2 2 2h368l2-2 2-2V16l-2-2-2-2H16l-2 2m152 57v24h39l39 1v26l-13 1h-13l-2 5-1 8-1 3v2l-2 5a176 176 0 0 1-24 45 120 120 0 0 1-11 14 119 119 0 0 0 23 21l19 12c3 2 3 3 7-7a122 122 0 0 1 3-10 94 94 0 0 1 4-10 71 71 0 0 0 3-6v-1l1-2a157 157 0 0 0 6-16 201 201 0 0 1 8-21l1-3a1041 1041 0 0 1 4-11 230 230 0 0 1 28 0v2l1 1v2l2 4 1 3a318 318 0 0 1 13 36v1l2 5 1 2 1 3a115 115 0 0 1 4 11 126 126 0 0 1 2 6 104 104 0 0 1 4 11 100 100 0 0 1 4 12 401 401 0 0 0 9 22 1344 1344 0 0 1 19 55h-25l-1-1-2-4a417 417 0 0 0-15-44l-1-3h-70l-1 3a39 39 0 0 1-2 4v2l-1 2-1 1v1l-1 2-2 6a339 339 0 0 1-11 30v1h-24l4-11a206 206 0 0 0 7-19 348 348 0 0 0 11-30c1-2 1-1-5-4a195 195 0 0 1-36-25l-11-9c-5-4-4-3-7-1l-2 1-2 1-1 2-2 1a480 480 0 0 1-53 33c-7 5-5 5-13-6s-7-10-3-13a1939 1939 0 0 0 59-40c2-2 2-2 0-4a318 318 0 0 1-34-43l-8-19v-1h27l2 4a137 137 0 0 0 32 43c2 0 11-9 16-15a98 98 0 0 0 16-33c2-6 3-14 2-16h-68l-68-1-1-13V96l2-1h81V72l31-1m102 107v1l-1 2-2 5-1 2v3l-1 1-1 3-2 5a62 62 0 0 1-2 7l-2 3a163 163 0 0 0-5 16l-3 8-7 18c-1 3-3 3 27 3l27-1-4-14a321 321 0 0 1-11-30 700 700 0 0 0-12-32" fill="#3464ac"/></g></svg>';
 		$errMsg = ($this->missingTranslationCount > 1) ? 'errors' : 'error';
+
 		return '<span title="Contributte/Translation">' .
 			$icon .
 			'&nbsp;<strong>' .
@@ -123,30 +124,6 @@ class Panel implements IBarPanel
 		return implode('', $panel);
 	}
 
-	/**
-	 * @param array<array<string>> $resources
-	 */
-	private static function createResourcePanelHelper(
-		array $resources,
-		string $class
-	): string
-	{
-		$string = '<table class="tracy-sortable"><colgroup><col style="width: 10%"><col style="width: 10%"><col style="width: 80%"></colgroup>';
-		$string .= '<tr><th>Locale</th><th>Domain</th><th>File name</th></tr>';
-
-		foreach ($resources as $k1 => $v1) {
-			foreach ($v1 as $k2 => $v2) {
-				$string .= '<tr class="' . $class . '">';
-				$string .= '<td>' . htmlspecialchars($k1) . '</td>';
-				$string .= '<td>' . htmlspecialchars($v2) . '</td>';
-				$string .= '<td>' . htmlspecialchars(dirname($k2)) . '/<strong>' . htmlspecialchars(basename($k2)) . '</strong></td>';
-				$string .= '</tr>';
-			}
-		}
-
-		return $string . '</table>';
-	}
-
 	public function addMissingTranslation(
 		string $id,
 		string $domain
@@ -218,6 +195,30 @@ class Panel implements IBarPanel
 	public function getIgnoredResources(): array
 	{
 		return $this->ignoredResources;
+	}
+
+	/**
+	 * @param array<array<string>> $resources
+	 */
+	private static function createResourcePanelHelper(
+		array $resources,
+		string $class
+	): string
+	{
+		$string = '<table class="tracy-sortable"><colgroup><col style="width: 10%"><col style="width: 10%"><col style="width: 80%"></colgroup>';
+		$string .= '<tr><th>Locale</th><th>Domain</th><th>File name</th></tr>';
+
+		foreach ($resources as $k1 => $v1) {
+			foreach ($v1 as $k2 => $v2) {
+				$string .= '<tr class="' . $class . '">';
+				$string .= '<td>' . htmlspecialchars($k1) . '</td>';
+				$string .= '<td>' . htmlspecialchars($v2) . '</td>';
+				$string .= '<td>' . htmlspecialchars(dirname($k2)) . '/<strong>' . htmlspecialchars(basename($k2)) . '</strong></td>';
+				$string .= '</tr>';
+			}
+		}
+
+		return $string . '</table>';
 	}
 
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Translation\Translator as SymfonyTranslator;
 class Translator extends SymfonyTranslator implements ITranslator
 {
 
+	public bool $returnOriginalMessage = true;
+
 	private LocaleResolver $localeResolver;
 
 	private FallbackResolver $fallbackResolver;
@@ -25,8 +27,6 @@ class Translator extends SymfonyTranslator implements ITranslator
 	private ?string $cacheDir;
 
 	private bool $debug;
-
-	public bool $returnOriginalMessage = true;
 
 	/** @var array<string>|null */
 	private ?array $localesWhitelist = null;
@@ -155,6 +155,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 	): self
 	{
 		$this->prefix[] = $string;
+
 		return $this;
 	}
 
@@ -176,6 +177,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 	): self
 	{
 		$this->translateKeyGenerator = $generator;
+
 		return $this;
 	}
 
@@ -224,12 +226,13 @@ class Translator extends SymfonyTranslator implements ITranslator
 	{
 		$locales = array_keys($this->resourcesLocales);
 		sort($locales);
+
 		return $locales;
 	}
 
 	public function addResource(
 		string $format,
-		$resource,
+		mixed $resource,
 		string $locale,
 		?string $domain = null
 	): void
@@ -271,6 +274,7 @@ class Translator extends SymfonyTranslator implements ITranslator
 	): self
 	{
 		$this->psrLogger = $psrLogger;
+
 		return $this;
 	}
 
@@ -284,16 +288,13 @@ class Translator extends SymfonyTranslator implements ITranslator
 	): self
 	{
 		$this->tracyPanel = $tracyPanel;
+
 		return $this;
 	}
 
-	/**
-	 * @param mixed $message
-	 * @param mixed ...$parameters
-	 */
 	public function translate(
-		$message,
-		...$parameters
+		mixed $message,
+		mixed ...$parameters
 	): string
 	{
 		if ($message === null || $message === '') {

--- a/src/Wrappers/Message.php
+++ b/src/Wrappers/Message.php
@@ -10,12 +10,9 @@ class Message
 	/** @var array<mixed> */
 	public array $parameters;
 
-	/**
-	 * @param array<mixed> ...$parameters
-	 */
 	public function __construct(
 		string $message,
-		...$parameters
+		mixed ...$parameters
 	)
 	{
 		$this->message = $message;

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -297,7 +297,7 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function test12(): void
 	{
-		Assert::exception(static function () {
+		Assert::exception(static function (): void {
 			Container::of()
 				->withDefaults()
 				->withCompiler(function (Compiler $compiler): void {

--- a/tests/Tests/Loaders/NetteDatabaseTest.phpt
+++ b/tests/Tests/Loaders/NetteDatabaseTest.phpt
@@ -20,7 +20,19 @@ final class NetteDatabaseTest extends TestAbstract
 
 	private Connection $connection;
 
-	protected function setUp()
+	public function test01(): void
+	{
+		$this->connection->query(file_get_contents(__DIR__ . '/../../sql.sql'));
+		$this->translator->setLocale('cs_CZ');
+
+		Assert::same('Ahoj', $this->translator->translate('db_table.hello'));
+
+		$this->translator->setLocale('en_US');
+
+		Assert::same('Hello', $this->translator->translate('db_table.hello'));
+	}
+
+	protected function setUp(): void
 	{
 		parent::setUp();
 
@@ -51,18 +63,6 @@ final class NetteDatabaseTest extends TestAbstract
 		} catch (ConnectionException $e) {
 			$this->skip('Database not connected');
 		}
-	}
-
-	public function test01(): void
-	{
-		$this->connection->query(file_get_contents(__DIR__ . '/../../sql.sql'));
-		$this->translator->setLocale('cs_CZ');
-
-		Assert::same('Ahoj', $this->translator->translate('db_table.hello'));
-
-		$this->translator->setLocale('en_US');
-
-		Assert::same('Hello', $this->translator->translate('db_table.hello'));
 	}
 
 }

--- a/tests/Tests/LocaleResolverMock.php
+++ b/tests/Tests/LocaleResolverMock.php
@@ -15,6 +15,7 @@ final class LocaleResolverMock implements ResolverInterface
 	): self
 	{
 		$this->locale = $locale;
+
 		return $this;
 	}
 

--- a/tests/Tests/LocalesResolvers/HeaderTest.phpt
+++ b/tests/Tests/LocalesResolvers/HeaderTest.phpt
@@ -51,32 +51,23 @@ final class HeaderTest extends TestAbstract
 					return new UrlScript();
 				}
 
-				/**
-				 * @return mixed
-				 */
 				public function getQuery(
 					?string $key = null
-				)
+				): mixed
 				{
 					return null;
 				}
 
-				/**
-				 * @return mixed
-				 */
 				public function getPost(
 					?string $key = null
-				)
+				): mixed
 				{
 					return null;
 				}
 
-				/**
-				 * @return mixed
-				 */
 				public function getFile(
 					string $key
-				)
+				): mixed
 				{
 					return null;
 				}
@@ -89,12 +80,9 @@ final class HeaderTest extends TestAbstract
 					return [];
 				}
 
-				/**
-				 * @return mixed
-				 */
 				public function getCookie(
 					string $key
-				)
+				): mixed
 				{
 					return null;
 				}
@@ -118,6 +106,7 @@ final class HeaderTest extends TestAbstract
 				{
 					return true;
 				}
+
 				public function getHeader(
 					string $header
 				): ?string

--- a/tests/Tests/PsrLoggerMock.php
+++ b/tests/Tests/PsrLoggerMock.php
@@ -16,6 +16,7 @@ final class PsrLoggerMock extends AbstractLogger
 		array $context = []
 	)
 	{
+		// testing mock
 	}
 
 }

--- a/tests/Toolkit/Container.php
+++ b/tests/Toolkit/Container.php
@@ -11,11 +11,10 @@ use Tests\LocaleResolverMock;
 final class Container
 {
 
-	/** @var string */
-	private $key;
+	private string $key;
 
 	/** @var callable[] */
-	private $onCompile = [];
+	private array $onCompile = [];
 
 	public function __construct(string $key)
 	{


### PR DESCRIPTION
Use contributte/qa instead of ninjify/qa in an attempt to fix `spaceIndent` does not exist. This is handled differently in the PHPCSStandards/PHP_CodeSniffer 3.8.0, the property seems to be tabIndent, and always was maybe.

The change required some style updates to the code base to adhere to the contributte standard.

`StaticCallNode` is an alias of `StaticMethodCallNode` in Latte 3.0.12  But the alias is defined in the new class file but maybe instead of loading the file, a new alias map should be created?