### PR TITLE
Added support for symfony translations providers like loco

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "nette/routing": "^3.0",
     "nette/utils": "^3.2.1|~4.0.0",
     "symfony/translation": "^6.0|^7.0",
-    "symfony/config": "^6.0|^7.0"
+    "symfony/config": "^6.0|^7.0",
+		"symfony/finder": "^6.0|^7.0"
   },
   "require-dev": {
     "doctrine/orm": "^2.8",

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -40,8 +40,6 @@ use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Provider\TranslationProviderCollectionFactory;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Component\Translation\Provider\Dsn;
 use Contributte\Translation\Dumpers\NeonFileDumper;
 use Symfony\Component\Translation\Writer\TranslationWriter;
 use Symfony\Component\Translation\Reader\TranslationReader;
@@ -421,4 +419,3 @@ class TranslationExtension extends CompilerExtension
 	}
 
 }
-;

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -412,10 +412,6 @@ class TranslationExtension extends CompilerExtension
 		ClassType $class
 	): void
 	{
-		$builder = $this->getContainerBuilder();
-		$providerCollections = $builder->getDefinition($this->prefix('providerCollection'));
-		bdump($providerCollections);
-
 		if (!$this->config->debug || !$this->config->debugger) {
 			return;
 		}

--- a/src/Dumpers/NeonFileDumper.php
+++ b/src/Dumpers/NeonFileDumper.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Nette neon dumper for contributte translation and symfony translation
+ *
+ * (c) Lukas Divacky <lukas.divacky@ldtech.cz>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Contributte\Translation\Dumpers;
+
+use Symfony\Component\Translation\Exception\LogicException;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Util\ArrayConverter;
+use Symfony\Component\Translation\Dumper\FileDumper;
+use Symfony\Component\Yaml\Yaml;
+use Nette\Neon\Neon as NetteNeon;
+
+/**
+ * NeonFileDumper generates yaml files from a message catalogue.
+ *
+ * @author Lukas Divacky <lukas.divacky@ldtech.cz>
+ */
+class NeonFileDumper extends FileDumper
+{
+    private string $extension;
+
+    public function __construct(string $extension = 'neon')
+    {
+        $this->extension = $extension;
+    }
+
+    public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
+    {
+        if (!class_exists(NetteNeon::class)) {
+            throw new LogicException('Dumping translations in the neon format requires the Nette neon component.');
+        }
+
+        $data = $messages->all($domain);
+
+		$data = ArrayConverter::expandToTree($data);
+
+		$neon = NetteNeon::encode($data, true);
+
+		return $neon;
+
+    }
+
+    protected function getExtension(): string
+    {
+        return $this->extension;
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -12,6 +12,9 @@ use Nette\Utils\Strings;
 use Nette\Utils\Validators;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\Translator as SymfonyTranslator;
+use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
+use Symfony\Component\Translation\Provider\Dsn;
+
 
 class Translator extends SymfonyTranslator implements ITranslator
 {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -12,9 +12,6 @@ use Nette\Utils\Strings;
 use Nette\Utils\Validators;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\Translator as SymfonyTranslator;
-use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
-use Symfony\Component\Translation\Provider\Dsn;
-
 
 class Translator extends SymfonyTranslator implements ITranslator
 {


### PR DESCRIPTION
Added support for symfony translations providers like loco (https://localise.biz/)

https://symfony.com/doc/current/translation.html#installing-and-configuring-a-third-party-provider

New config items for translation in config.neon looks like:
	providers:
		loco: 
			provider: Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory
			dsn: %loco.dsn%
			locales: [cs_CZ, sk_SK]
			domains: [] 