### PR TITLE
Remove dependency on Nette\Http\Request

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,7 +38,7 @@ parameters:
 		# -------------------------------------------------------------------
 		-
 			message: """
-				#^Fetching class constant class of deprecated class Nette\\\\Bridges\\\\ApplicationLatte\\\\ILatteFactory\\:
+				#^Fetching class constant class of deprecated interface Nette\\\\Bridges\\\\ApplicationLatte\\\\ILatteFactory\\:
 				use Nette\\\\Bridges\\\\ApplicationLatte\\\\LatteFactory$#
 			"""
 			count: 1
@@ -46,7 +46,7 @@ parameters:
 
 		-
 			message: """
-				#^Fetching class constant class of deprecated class Nette\\\\Localization\\\\ITranslator\\:
+				#^Fetching class constant class of deprecated interface Nette\\\\Localization\\\\ITranslator\\:
 				use Nette\\\\Localization\\\\Translator$#
 			"""
 			count: 2

--- a/tests/Tests/LocalesResolvers/HeaderTest.phpt
+++ b/tests/Tests/LocalesResolvers/HeaderTest.phpt
@@ -2,13 +2,10 @@
 
 namespace Tests\LocalesResolvers;
 
-use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\LocalesResolvers\Header;
 use Contributte\Translation\Translator;
 use Mockery;
-use Nette\Http\IRequest;
 use Nette\Http\Request;
-use Nette\Http\UrlImmutable;
 use Nette\Http\UrlScript;
 use Tester\Assert;
 use Tests\TestAbstract;
@@ -29,137 +26,6 @@ final class HeaderTest extends TestAbstract
 		Assert::same('en', $this->resolve('da, en-us;q=0.8, en;q=0.7', ['en']));
 		Assert::same('en', $this->resolve('da, en_us', ['en']));
 		Assert::same('en-us', $this->resolve('da, en_us', ['en', 'en-us']));
-	}
-
-	public function test02(): void
-	{
-		Assert::exception(static function (): void {
-			new Header(new class implements IRequest {
-
-				public function getReferer(): ?UrlImmutable
-				{
-					return null;
-				}
-
-				public function isSameSite(): bool
-				{
-					return true;
-				}
-
-				public function getUrl(): UrlScript
-				{
-					return new UrlScript();
-				}
-
-				/**
-				 * @return mixed
-				 */
-				public function getQuery(
-					?string $key = null
-				)
-				{
-					return null;
-				}
-
-				/**
-				 * @return mixed
-				 */
-				public function getPost(
-					?string $key = null
-				)
-				{
-					return null;
-				}
-
-				/**
-				 * @return mixed
-				 */
-				public function getFile(
-					string $key
-				)
-				{
-					return null;
-				}
-
-				/**
-				 * @return array<\Nette\Http\FileUpload>
-				 */
-				public function getFiles(): array
-				{
-					return [];
-				}
-
-				/**
-				 * @return mixed
-				 */
-				public function getCookie(
-					string $key
-				)
-				{
-					return null;
-				}
-
-				/**
-				 * @return array<string>
-				 */
-				public function getCookies(): array
-				{
-					return [];
-				}
-
-				public function getMethod(): string
-				{
-					return '';
-				}
-
-				public function isMethod(
-					string $method
-				): bool
-				{
-					return true;
-				}
-				public function getHeader(
-					string $header
-				): ?string
-				{
-					return null;
-				}
-
-				/**
-				 * @return array<string>
-				 */
-				public function getHeaders(): array
-				{
-					return [];
-				}
-
-				public function isSecured(): bool
-				{
-					return true;
-				}
-
-				public function isAjax(): bool
-				{
-					return true;
-				}
-
-				public function getRemoteAddress(): ?string
-				{
-					return null;
-				}
-
-				public function getRemoteHost(): ?string
-				{
-					return null;
-				}
-
-				public function getRawBody(): ?string
-				{
-					return null;
-				}
-
-			});
-		}, InvalidArgument::class, 'Header locale resolver need "' . Request::class . '" or his child for using "detectLanguage" method.');
 	}
 
 	/**

--- a/tests/Tests/TestAbstract.php
+++ b/tests/Tests/TestAbstract.php
@@ -20,7 +20,7 @@ abstract class TestAbstract extends TestCase
 	)
 	{
 		if (class_exists('\Composer\InstalledVersions')) { // Composer 2
-			$netteUtilsVersion = InstalledVersions::getPrettyVersion('nette/utils');
+			$netteUtilsVersion = ltrim(InstalledVersions::getPrettyVersion('nette/utils'), 'v');
 		} else { // Composer 1
 			$composerRaw = FileSystem::read(__DIR__ . '/../../composer.lock');
 


### PR DESCRIPTION
Hi, there was a problem when you try to use this exntesion with php runtimes like swoole/roadrunner/falconphp, because you can't have Nette Request object, but you need your own implementation of IRequest that will switch its variables and state between requests.

The problem wasn't only Header resolver itself, because if you are not using it, extension will try to create it in DI and it fails in constructor, so extension could not work at all, so I moved one method for resolving locale from Nette Request to Header resolver.