### PR TITLE
Run tests on PHP 8.4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -149,7 +149,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.0", "8.1", "8.2", "8.3" ]
+        php-version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
         operating-system: [ "ubuntu-latest" ]
         composer-args: [ "" ]
         include:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -130,7 +130,7 @@ jobs:
 
   tests:
     name: "Tests"
-    runs-on: "${{ matrix.operating-system }}"
+    runs-on: "ubuntu-latest"
     services:
       mariadb:
         image: "mariadb:10.4"
@@ -149,11 +149,9 @@ jobs:
     strategy:
       matrix:
         php-version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
-        operating-system: [ "ubuntu-latest" ]
         composer-args: [ "" ]
         include:
           - php-version: "8.0"
-            operating-system: "ubuntu-latest"
             composer-args: "--prefer-lowest"
       fail-fast: false
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -153,6 +153,8 @@ jobs:
         include:
           - php-version: "8.0"
             composer-args: "--prefer-lowest"
+          - php-version: "8.1"
+            composer-args: "--prefer-lowest"
       fail-fast: false
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,6 @@ on:
 env:
   extensions: "json, pdo_mysql, pdo_sqlite, intl"
   cache-version: "1"
-  composer-version: "v1"
   composer-install: "composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-stable"
 
 jobs:
@@ -45,7 +44,7 @@ jobs:
         with:
           php-version: "8.0"
           extensions: "${{ env.extensions }}"
-          tools: "composer:${{ env.composer-version }}"
+          tools: "composer"
 
       - name: "Setup problem matchers for PHP"
         run: 'echo "::add-matcher::${{ runner.tool_cache }}/php.json"'
@@ -107,7 +106,7 @@ jobs:
         with:
           php-version: "8.1"
           extensions: "${{ env.extensions }}"
-          tools: "composer:${{ env.composer-version }}"
+          tools: "composer"
 
       - name: "Setup problem matchers for PHP"
         run: 'echo "::add-matcher::${{ runner.tool_cache }}/php.json"'
@@ -182,7 +181,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.extensions }}"
-          tools: "composer:${{ env.composer-version }}"
+          tools: "composer"
 
       - name: "Setup problem matchers for PHP"
         run: 'echo "::add-matcher::${{ runner.tool_cache }}/php.json"'
@@ -250,7 +249,7 @@ jobs:
           php-version: "8.0"
           coverage: "xdebug"
           extensions: "${{ env.extensions }}"
-          tools: "composer:${{ env.composer-version }}"
+          tools: "composer"
 
       - name: "Setup problem matchers for PHP"
         run: 'echo "::add-matcher::${{ runner.tool_cache }}/php.json"'


### PR DESCRIPTION
This PR
- adds PHP 8.4 to supported PHP versions by running tests on 8.4, no other code changes
- drops Composer 1.x from tests as it will soon be unsupported by Packagist anyway (and because tests fail with Composer 1.x for some reason)
- tests with lowest dependencies also on PHP 8.1 (newer versions fail with lowest deps so they're not tested)