### PR TITLE
Migrate coverage reporting to Codecov

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -271,11 +271,11 @@ jobs:
       - name: "Tests"
         run: "make coverage"
 
-      - name: "Coveralls.io"
+      - name: "Codecov"
+        uses: "codecov/codecov-action@v4"
+        with:
+          files: "./coverage.xml"
+          fail_ci_if_error: true
+          verbose: true
         env:
-          CI_NAME: github
-          CI: true
-          COVERALLS_REPO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.5.2/php-coveralls.phar
-          php php-coveralls.phar --verbose --config tests/.coveralls.yml
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
     <a href="https://github.com/contributte/translation/actions"><img src="https://badgen.net/github/checks/contributte/translation"></a>
-    <a href="https://coveralls.io/r/contributte/translation"><img src="https://badgen.net/coveralls/c/github/contributte/translation"></a>
+    <a href="https://codecov.io/gh/contributte/translation"><img src="https://badgen.net/codecov/c/github/contributte/translation"></a>
     <a href="https://packagist.org/packages/contributte/translation"><img src="https://badgen.net/packagist/dm/contributte/translation"></a>
     <a href="https://packagist.org/packages/contributte/translation"><img src="https://badgen.net/packagist/v/contributte/translation"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,3 +1,0 @@
-service_name: github-action
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## What changed
- replaced the README Coveralls badge with the Codecov badge/link pattern used in contributte/vite
- switched the coverage upload step from php-coveralls to codecov/codecov-action
- removed the obsolete `tests/.coveralls.yml` file

## Why
- finishes the Coveralls-to-Codecov migration for this repository and removes the last Coveralls-specific CI wiring

Related: contributte/contributte#72