### PR TITLE
Support dynamic tempDir parameter in TranslationExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "symfony/config": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
+    "contributte/tester": "^0.4.0",
     "doctrine/orm": "^2.8",
     "mockery/mockery": "^1.4",
     "nette/application": "^3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "symfony/config": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
-    "contributte/tester": "^0.4.0",
     "doctrine/orm": "^2.8",
     "mockery/mockery": "^1.4",
     "nette/application": "^3.1.0",

--- a/src/DI/TranslationExtension.php
+++ b/src/DI/TranslationExtension.php
@@ -52,7 +52,7 @@ use Tracy\IBarPanel;
  *     loaders: array<string, class-string|Statement>,
  *     dirs: array<string>,
  *     cache: array{
- *         dir: string,
+ *         dir: string|Statement,
  *         factory: class-string,
  *         vary: array<string>,
  *     },
@@ -69,11 +69,11 @@ class TranslationExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		$builder = $this->getContainerBuilder();
-		$tempDir = $builder->parameters['tempDir'];
+		$tempDir = $builder->parameters['tempDir'] ?? null;
 
-		if (!is_string($tempDir)) {
-			throw new InvalidArgument('Container parameter "tempDir" must be a string.');
-		}
+		$cacheDir = is_string($tempDir)
+			? $tempDir . '/cache/translation'
+			: new Statement('::implode', [[$tempDir, '/cache/translation']]);
 
 		return Expect::structure([
 			'debug' => Expect::bool($builder->parameters['debugMode']),
@@ -119,7 +119,7 @@ class TranslationExtension extends CompilerExtension
 			]),
 			'dirs' => Expect::listOf('string')->default([]),
 			'cache' => Expect::structure([
-				'dir' => Expect::string($tempDir . '/cache/translation'),
+				'dir' => Expect::string($cacheDir),
 				'factory' => Expect::string(ConfigCacheFactory::class),
 				'vary' => Expect::listOf('string')->default([]),
 			])->castTo('array'),

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -8,9 +8,9 @@ use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\LocalesResolvers\ResolverInterface;
 use Contributte\Translation\Tracy\Panel;
 use Contributte\Translation\Translator;
-use Contributte\Tester\Utils\ContainerBuilder;
 use Nette\DI\Compiler;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Container as NetteContainer;
 use Nette\DI\ContainerLoader;
 use Nette\DI\MissingServiceException;
 use Nette\InvalidStateException;
@@ -316,19 +316,22 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function testCacheDirFromStringTempDir(): void
 	{
-		$container = ContainerBuilder::of()
-			->withTempDir(ToolkitTests::TEMP_PATH)
-			->withCompiler(function (Compiler $compiler): void {
-				$compiler->addExtension('translation', new TranslationExtension());
-				$compiler->addConfig([
-					'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
-					'translation' => [
-						'localeResolvers' => [LocaleResolverMock::class],
-						'dirs' => [__DIR__ . '/../../lang'],
-					],
-				]);
-			})
-			->build();
+		$loader = new ContainerLoader(ToolkitTests::TEMP_PATH, true);
+
+		/** @var class-string $class */
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('translation', new TranslationExtension());
+			$compiler->addConfig([
+				'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
+				'translation' => [
+					'localeResolvers' => [LocaleResolverMock::class],
+					'dirs' => [__DIR__ . '/../../lang'],
+				],
+			]);
+		}, uniqid(random_bytes(16)));
+
+		$container = new $class();
+		assert($container instanceof NetteContainer);
 
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);
@@ -338,19 +341,22 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function testCacheDirFromNullTempDir(): void
 	{
-		$container = ContainerBuilder::of()
-			->withTempDir(ToolkitTests::TEMP_PATH)
-			->withCompiler(function (Compiler $compiler): void {
-				$compiler->addExtension('translation', new TranslationExtension());
-				$compiler->addConfig([
-					'parameters' => ['tempDir' => null, 'debugMode' => false],
-					'translation' => [
-						'localeResolvers' => [LocaleResolverMock::class],
-						'dirs' => [__DIR__ . '/../../lang'],
-					],
-				]);
-			})
-			->build();
+		$loader = new ContainerLoader(ToolkitTests::TEMP_PATH, true);
+
+		/** @var class-string $class */
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('translation', new TranslationExtension());
+			$compiler->addConfig([
+				'parameters' => ['tempDir' => null, 'debugMode' => false],
+				'translation' => [
+					'localeResolvers' => [LocaleResolverMock::class],
+					'dirs' => [__DIR__ . '/../../lang'],
+				],
+			]);
+		}, uniqid(random_bytes(16)));
+
+		$container = new $class();
+		assert($container instanceof NetteContainer);
 
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);
@@ -360,19 +366,23 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function testCacheDirFromDynamicTempDir(): void
 	{
-		$container = ContainerBuilder::of()
-			->withTempDir(ToolkitTests::TEMP_PATH)
-			->withCompiler(function (Compiler $compiler): void {
-				$compiler->addExtension('translation', new TranslationExtension());
-				$compiler->addConfig([
-					'parameters' => ['debugMode' => false],
-					'translation' => [
-						'localeResolvers' => [LocaleResolverMock::class],
-						'dirs' => [__DIR__ . '/../../lang'],
-					],
-				]);
-			})
-			->buildWith(['tempDir' => 'relative/temp']);
+		$loader = new ContainerLoader(ToolkitTests::TEMP_PATH, true);
+
+		/** @var class-string $class */
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('translation', new TranslationExtension());
+			$compiler->addConfig([
+				'parameters' => ['debugMode' => false],
+				'translation' => [
+					'localeResolvers' => [LocaleResolverMock::class],
+					'dirs' => [__DIR__ . '/../../lang'],
+				],
+			]);
+			$compiler->setDynamicParameterNames(['tempDir']);
+		}, uniqid(random_bytes(16)));
+
+		$container = new $class(['tempDir' => 'relative/temp']);
+		assert($container instanceof NetteContainer);
 
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);
@@ -382,20 +392,23 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function testCacheDirFromExplicitConfig(): void
 	{
-		$container = ContainerBuilder::of()
-			->withTempDir(ToolkitTests::TEMP_PATH)
-			->withCompiler(function (Compiler $compiler): void {
-				$compiler->addExtension('translation', new TranslationExtension());
-				$compiler->addConfig([
-					'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
-					'translation' => [
-						'localeResolvers' => [LocaleResolverMock::class],
-						'dirs' => [__DIR__ . '/../../lang'],
-						'cache' => ['dir' => 'explicit/cache/dir'],
-					],
-				]);
-			})
-			->build();
+		$loader = new ContainerLoader(ToolkitTests::TEMP_PATH, true);
+
+		/** @var class-string $class */
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('translation', new TranslationExtension());
+			$compiler->addConfig([
+				'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
+				'translation' => [
+					'localeResolvers' => [LocaleResolverMock::class],
+					'dirs' => [__DIR__ . '/../../lang'],
+					'cache' => ['dir' => 'explicit/cache/dir'],
+				],
+			]);
+		}, uniqid(random_bytes(16)));
+
+		$container = new $class();
+		assert($container instanceof NetteContainer);
 
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -11,7 +11,6 @@ use Contributte\Translation\Translator;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Nette\DI\Compiler;
 use Nette\DI\CompilerExtension;
-use Nette\DI\Container as NetteContainer;
 use Nette\DI\ContainerLoader;
 use Nette\DI\MissingServiceException;
 use Nette\InvalidStateException;
@@ -320,11 +319,21 @@ final class TranslationExtensionTest extends TestAbstract
 		$container = ContainerBuilder::of()
 			->withTempDir(ToolkitTests::TEMP_PATH)
 			->withCompiler(function (Compiler $compiler): void {
-				$this->configureTranslation($compiler, ['tempDir' => 'relative/temp']);
+				$compiler->addExtension('translation', new TranslationExtension());
+				$compiler->addConfig([
+					'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
+					'translation' => [
+						'localeResolvers' => [LocaleResolverMock::class],
+						'dirs' => [__DIR__ . '/../../lang'],
+					],
+				]);
 			})
 			->build();
 
-		Assert::same('relative/temp/cache/translation', $this->getTranslator($container)->getCacheDir());
+		/** @var Translator $translator */
+		$translator = $container->getByType(ITranslator::class);
+
+		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
 	}
 
 	public function testCacheDirFromNullTempDir(): void
@@ -332,11 +341,21 @@ final class TranslationExtensionTest extends TestAbstract
 		$container = ContainerBuilder::of()
 			->withTempDir(ToolkitTests::TEMP_PATH)
 			->withCompiler(function (Compiler $compiler): void {
-				$this->configureTranslation($compiler, ['tempDir' => null]);
+				$compiler->addExtension('translation', new TranslationExtension());
+				$compiler->addConfig([
+					'parameters' => ['tempDir' => null, 'debugMode' => false],
+					'translation' => [
+						'localeResolvers' => [LocaleResolverMock::class],
+						'dirs' => [__DIR__ . '/../../lang'],
+					],
+				]);
 			})
 			->build();
 
-		Assert::same('/cache/translation', $this->getTranslator($container)->getCacheDir());
+		/** @var Translator $translator */
+		$translator = $container->getByType(ITranslator::class);
+
+		Assert::same('/cache/translation', $translator->getCacheDir());
 	}
 
 	public function testCacheDirFromDynamicTempDir(): void
@@ -344,11 +363,21 @@ final class TranslationExtensionTest extends TestAbstract
 		$container = ContainerBuilder::of()
 			->withTempDir(ToolkitTests::TEMP_PATH)
 			->withCompiler(function (Compiler $compiler): void {
-				$this->configureTranslation($compiler);
+				$compiler->addExtension('translation', new TranslationExtension());
+				$compiler->addConfig([
+					'parameters' => ['debugMode' => false],
+					'translation' => [
+						'localeResolvers' => [LocaleResolverMock::class],
+						'dirs' => [__DIR__ . '/../../lang'],
+					],
+				]);
 			})
 			->buildWith(['tempDir' => 'relative/temp']);
 
-		Assert::same('relative/temp/cache/translation', $this->getTranslator($container)->getCacheDir());
+		/** @var Translator $translator */
+		$translator = $container->getByType(ITranslator::class);
+
+		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
 	}
 
 	public function testCacheDirFromExplicitConfig(): void
@@ -356,37 +385,22 @@ final class TranslationExtensionTest extends TestAbstract
 		$container = ContainerBuilder::of()
 			->withTempDir(ToolkitTests::TEMP_PATH)
 			->withCompiler(function (Compiler $compiler): void {
-				$this->configureTranslation($compiler, ['tempDir' => 'relative/temp'], [
-					'cache' => ['dir' => 'explicit/cache/dir'],
+				$compiler->addExtension('translation', new TranslationExtension());
+				$compiler->addConfig([
+					'parameters' => ['tempDir' => 'relative/temp', 'debugMode' => false],
+					'translation' => [
+						'localeResolvers' => [LocaleResolverMock::class],
+						'dirs' => [__DIR__ . '/../../lang'],
+						'cache' => ['dir' => 'explicit/cache/dir'],
+					],
 				]);
 			})
 			->build();
 
-		Assert::same('explicit/cache/dir', $this->getTranslator($container)->getCacheDir());
-	}
-
-	/**
-	 * @param array<string, mixed> $parameters
-	 * @param array<string, mixed> $translation
-	 */
-	private function configureTranslation(Compiler $compiler, array $parameters = [], array $translation = []): void
-	{
-		$compiler->addExtension('translation', new TranslationExtension());
-		$compiler->addConfig([
-			'parameters' => array_merge(['debugMode' => false], $parameters),
-			'translation' => array_merge([
-				'localeResolvers' => [LocaleResolverMock::class],
-				'dirs' => [__DIR__ . '/../../lang'],
-			], $translation),
-		]);
-	}
-
-	private function getTranslator(NetteContainer $container): Translator
-	{
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);
 
-		return $translator;
+		Assert::same('explicit/cache/dir', $translator->getCacheDir());
 	}
 
 }

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -8,8 +8,10 @@ use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\LocalesResolvers\ResolverInterface;
 use Contributte\Translation\Tracy\Panel;
 use Contributte\Translation\Translator;
+use Contributte\Tester\Utils\ContainerBuilder;
 use Nette\DI\Compiler;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Container as NetteContainer;
 use Nette\DI\ContainerLoader;
 use Nette\DI\MissingServiceException;
 use Nette\InvalidStateException;
@@ -29,6 +31,7 @@ use Tests\PsrLoggerMock;
 use Tests\TestAbstract;
 use Tests\Toolkit\Container;
 use Tests\Toolkit\Helpers as ToolkitHelpers;
+use Tests\Toolkit\Tests as ToolkitTests;
 use UnexpectedValueException;
 
 $container = require __DIR__ . '/../../bootstrap.php';
@@ -312,68 +315,74 @@ final class TranslationExtensionTest extends TestAbstract
 		}, InvalidArgument::class, 'Loader must implement interface "Symfony\Component\Translation\Loader\LoaderInterface".');
 	}
 
-	public function test13(): void
+	public function testCacheDirFromStringTempDir(): void
 	{
-		// tempDir as a plain string
-		$translator = $this->buildTranslator(['tempDir' => 'relative/temp']);
+		$container = ContainerBuilder::of()
+			->withTempDir(ToolkitTests::TEMP_PATH)
+			->withCompiler(function (Compiler $compiler): void {
+				$this->configureTranslation($compiler, ['tempDir' => 'relative/temp']);
+			})
+			->build();
 
-		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
+		Assert::same('relative/temp/cache/translation', $this->getTranslator($container)->getCacheDir());
 	}
 
-	public function test14(): void
+	public function testCacheDirFromNullTempDir(): void
 	{
-		// tempDir as null
-		$translator = $this->buildTranslator(['tempDir' => null]);
+		$container = ContainerBuilder::of()
+			->withTempDir(ToolkitTests::TEMP_PATH)
+			->withCompiler(function (Compiler $compiler): void {
+				$this->configureTranslation($compiler, ['tempDir' => null]);
+			})
+			->build();
 
-		Assert::same('/cache/translation', $translator->getCacheDir());
+		Assert::same('/cache/translation', $this->getTranslator($container)->getCacheDir());
 	}
 
-	public function test15(): void
+	public function testCacheDirFromDynamicTempDir(): void
 	{
-		// tempDir as a dynamic parameter (resolved at runtime)
-		$translator = $this->buildTranslator(['tempDir' => 'relative/temp'], [], ['tempDir']);
+		$container = ContainerBuilder::of()
+			->withTempDir(ToolkitTests::TEMP_PATH)
+			->withCompiler(function (Compiler $compiler): void {
+				$this->configureTranslation($compiler);
+			})
+			->buildWith(['tempDir' => 'relative/temp']);
 
-		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
+		Assert::same('relative/temp/cache/translation', $this->getTranslator($container)->getCacheDir());
 	}
 
-	public function test16(): void
+	public function testCacheDirFromExplicitConfig(): void
 	{
-		// cache.dir explicitly provided wins over tempDir
-		$translator = $this->buildTranslator(['tempDir' => 'relative/temp'], [
-			'cache' => ['dir' => 'explicit/cache/dir'],
-		]);
+		$container = ContainerBuilder::of()
+			->withTempDir(ToolkitTests::TEMP_PATH)
+			->withCompiler(function (Compiler $compiler): void {
+				$this->configureTranslation($compiler, ['tempDir' => 'relative/temp'], [
+					'cache' => ['dir' => 'explicit/cache/dir'],
+				]);
+			})
+			->build();
 
-		Assert::same('explicit/cache/dir', $translator->getCacheDir());
+		Assert::same('explicit/cache/dir', $this->getTranslator($container)->getCacheDir());
 	}
 
 	/**
 	 * @param array<string, mixed> $parameters
 	 * @param array<string, mixed> $translation
-	 * @param string[] $dynamicParameterNames
 	 */
-	private function buildTranslator(array $parameters, array $translation = [], array $dynamicParameterNames = []): Translator
+	private function configureTranslation(Compiler $compiler, array $parameters = [], array $translation = []): void
 	{
-		$loader = new ContainerLoader($this->container->getParameters()['tempDir'], true);
+		$compiler->addExtension('translation', new TranslationExtension());
+		$compiler->addConfig([
+			'parameters' => array_merge(['debugMode' => false], $parameters),
+			'translation' => array_merge([
+				'localeResolvers' => [LocaleResolverMock::class],
+				'dirs' => [__DIR__ . '/../../lang'],
+			], $translation),
+		]);
+	}
 
-		/** @var class-string $class */
-		$class = $loader->load(function (Compiler $compiler) use ($parameters, $translation, $dynamicParameterNames): void {
-			if ($dynamicParameterNames !== []) {
-				$compiler->setDynamicParameterNames($dynamicParameterNames);
-			}
-
-			$compiler->addExtension('translation', new TranslationExtension());
-			$compiler->addConfig([
-				'parameters' => array_merge(['debugMode' => false], $parameters),
-				'translation' => array_merge([
-					'localeResolvers' => [LocaleResolverMock::class],
-					'dirs' => [__DIR__ . '/../../lang'],
-				], $translation),
-			]);
-		}, uniqid(random_bytes(16)));
-
-		$container = new $class();
-		assert($container instanceof \Nette\DI\Container);
-
+	private function getTranslator(NetteContainer $container): Translator
+	{
 		/** @var Translator $translator */
 		$translator = $container->getByType(ITranslator::class);
 

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -311,6 +311,18 @@ final class TranslationExtensionTest extends TestAbstract
 		}, InvalidArgument::class, 'Loader must implement interface "Symfony\Component\Translation\Loader\LoaderInterface".');
 	}
 
+	public function test13(): void
+	{
+		$container = Container::of()
+			->withDefaults()
+			->withCompiler(function (Compiler $compiler): void {
+				$compiler->setDynamicParameterNames(['tempDir']);
+			})
+			->build();
+
+		Assert::notNull($container->getByType(ITranslator::class));
+	}
+
 }
 
 (new TranslationExtensionTest($container))->run();

--- a/tests/Tests/DI/TranslationExtensionTest.phpt
+++ b/tests/Tests/DI/TranslationExtensionTest.phpt
@@ -24,6 +24,7 @@ use Tester\Assert;
 use Tests\CustomTranslatorMock;
 use Tests\Fixtures\DummyLoader;
 use Tests\Helpers;
+use Tests\LocaleResolverMock;
 use Tests\PsrLoggerMock;
 use Tests\TestAbstract;
 use Tests\Toolkit\Container;
@@ -313,14 +314,70 @@ final class TranslationExtensionTest extends TestAbstract
 
 	public function test13(): void
 	{
-		$container = Container::of()
-			->withDefaults()
-			->withCompiler(function (Compiler $compiler): void {
-				$compiler->setDynamicParameterNames(['tempDir']);
-			})
-			->build();
+		// tempDir as a plain string
+		$translator = $this->buildTranslator(['tempDir' => 'relative/temp']);
 
-		Assert::notNull($container->getByType(ITranslator::class));
+		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
+	}
+
+	public function test14(): void
+	{
+		// tempDir as null
+		$translator = $this->buildTranslator(['tempDir' => null]);
+
+		Assert::same('/cache/translation', $translator->getCacheDir());
+	}
+
+	public function test15(): void
+	{
+		// tempDir as a dynamic parameter (resolved at runtime)
+		$translator = $this->buildTranslator(['tempDir' => 'relative/temp'], [], ['tempDir']);
+
+		Assert::same('relative/temp/cache/translation', $translator->getCacheDir());
+	}
+
+	public function test16(): void
+	{
+		// cache.dir explicitly provided wins over tempDir
+		$translator = $this->buildTranslator(['tempDir' => 'relative/temp'], [
+			'cache' => ['dir' => 'explicit/cache/dir'],
+		]);
+
+		Assert::same('explicit/cache/dir', $translator->getCacheDir());
+	}
+
+	/**
+	 * @param array<string, mixed> $parameters
+	 * @param array<string, mixed> $translation
+	 * @param string[] $dynamicParameterNames
+	 */
+	private function buildTranslator(array $parameters, array $translation = [], array $dynamicParameterNames = []): Translator
+	{
+		$loader = new ContainerLoader($this->container->getParameters()['tempDir'], true);
+
+		/** @var class-string $class */
+		$class = $loader->load(function (Compiler $compiler) use ($parameters, $translation, $dynamicParameterNames): void {
+			if ($dynamicParameterNames !== []) {
+				$compiler->setDynamicParameterNames($dynamicParameterNames);
+			}
+
+			$compiler->addExtension('translation', new TranslationExtension());
+			$compiler->addConfig([
+				'parameters' => array_merge(['debugMode' => false], $parameters),
+				'translation' => array_merge([
+					'localeResolvers' => [LocaleResolverMock::class],
+					'dirs' => [__DIR__ . '/../../lang'],
+				], $translation),
+			]);
+		}, uniqid(random_bytes(16)));
+
+		$container = new $class();
+		assert($container instanceof \Nette\DI\Container);
+
+		/** @var Translator $translator */
+		$translator = $container->getByType(ITranslator::class);
+
+		return $translator;
 	}
 
 }


### PR DESCRIPTION
## Summary
Updated `TranslationExtension` to support dynamic `tempDir` parameters that are resolved at container build time, rather than requiring a static string value.

## Key Changes
- Modified the `cache.dir` configuration schema to accept both `string` and `Statement` types, allowing for dynamic parameter resolution
- Changed `tempDir` parameter retrieval to use null coalescing (`?? null`) instead of throwing an exception when the parameter is not set
- Implemented conditional logic to handle both static string `tempDir` values and dynamic `Statement` instances:
  - For static strings: concatenates the path directly
  - For dynamic parameters: uses a `Statement` with `implode` to concatenate at runtime
- Added test case `test13()` to verify the extension works correctly when `tempDir` is configured as a dynamic parameter

## Implementation Details
The change allows the translation cache directory to be properly configured even when `tempDir` is a dynamic parameter (e.g., when using `setDynamicParameterNames()` in the compiler). This is achieved by deferring the path concatenation to runtime via a `Statement` object when the parameter cannot be resolved statically.

https://claude.ai/code/session_015WctUVqnDnBvxgpn8o6ZuB