### PR TITLE
Skip NetteDatabaseTest when database connection unavailable

### DIFF
--- a/tests/Tests/Loaders/NetteDatabaseTest.phpt
+++ b/tests/Tests/Loaders/NetteDatabaseTest.phpt
@@ -8,10 +8,17 @@ use Nette\Database\Connection;
 use Nette\Database\ConnectionException;
 use Nette\Localization\ITranslator;
 use Tester\Assert;
+use Tester\Environment;
 use Tests\Helpers;
 use Tests\TestAbstract;
 
 $container = require __DIR__ . '/../../bootstrap.php';
+
+try {
+	(new Connection('mysql:host=127.0.0.1;port=13306;dbname=test', 'root', '1234'))->connect();
+} catch (ConnectionException $e) {
+	Environment::skip('Database not connected');
+}
 
 final class NetteDatabaseTest extends TestAbstract
 {


### PR DESCRIPTION
This change adds a database connectivity check to the NetteDatabaseTest to gracefully skip the test suite when the database is not available, rather than failing with connection errors.

**Key changes:**
- Added `use Tester\Environment;` import to enable test skipping functionality
- Added a try-catch block that attempts to connect to the test database (MySQL on localhost:13306)
- If the connection fails with a `ConnectionException`, the test suite is skipped with an informative message
- This allows the test suite to run in environments where the database may not be available without causing test failures

**Implementation details:**
- The connection check uses the same credentials and database configuration that the tests would use
- The skip is triggered before the test class is defined, preventing any database-dependent tests from running
- This is a common pattern for integration tests that depend on external services

https://claude.ai/code/session_01A8V5dTVDGP1CJTsjzfmosR